### PR TITLE
Update password hashing

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "branch",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Branch",
   "author": "David, Isaac, Jake, Katie, Noah",
   "main": "server.js",

--- a/backend/server.js
+++ b/backend/server.js
@@ -433,13 +433,9 @@ function init() {
   CREATE TABLE IF NOT EXISTS users (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(48) UNIQUE,
-    losses INT NOT NULL DEFAULT 0,
-    forfeits INT NOT NULL DEFAULT 0,
-    games INT NOT NULL DEFAULT 0,
-    wins INT NOT NULL DEFAULT 0,
-    elo INT NOT NULL DEFAULT 1500,
-    password VARCHAR(128),
-    salt VARCHAR(32)
+    password VARCHAR(128) NOT NULL,
+    salt VARCHAR(32) NOT NULL,
+    enc_type varchar(32) NOT NULL DEFAULT 'sha512'
   );`, (error, results, fields) => {
       if(error) {
         console.log("ERROR", error);
@@ -447,9 +443,28 @@ function init() {
         console.log("Database Connection Failed, Retrying In 1 Second");
         setTimeout(init, 1000);
       } else {
-        console.log("Result", results);
-        console.log('Running on http://localhost:' + port);
-        http.listen(port);
+        dbQuery((db) => {
+          db.query(`
+          CREATE TABLE IF NOT EXISTS gameData (
+            id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            user_id INT NOT NULL,
+            losses INT NOT NULL DEFAULT 0,
+            games INT NOT NULL DEFAULT 0,
+            wins INT NOT NULL DEFAULT 0,
+            elo INT NOT NULL DEFAULT 1500
+          );`, (error, results, fields) => {
+            if(error) {
+              console.log("ERROR", error);
+              // throw error;
+              console.log("Database Query Failed, Retrying in 1 Second");
+              setTimeout(init, 1000);
+            } else {
+              console.log("Result", results);
+              console.log('Running on http://localhost:' + port);
+              http.listen(port);
+            }
+          });
+        });
       }
     });
   });

--- a/backend/server.js
+++ b/backend/server.js
@@ -433,7 +433,7 @@ function init() {
   CREATE TABLE IF NOT EXISTS users (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(48) UNIQUE,
-    password VARCHAR(128) NOT NULL,
+    password VARCHAR(1024) NOT NULL,
     salt VARCHAR(32) NOT NULL,
     enc_type varchar(32) NOT NULL DEFAULT 'sha512'
   );`, (error, results, fields) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -23,7 +23,7 @@ const SECRET = process.env.HASH_SECRET;
 const SALT_SIZE = 32; // salt is 32 bytes
 const MIN_PASSWORD_LENGTH = 6; // salt is 32 bytes
 const port = 8080;
-const version = "1.3.3";
+const version = "1.3.4";
 
 var session = expressSession({
   secret: SECRET,


### PR DESCRIPTION
Switch from default of sha 512 to pbkdf2, all previously hashed passwords are still supported and will be converted when users sign in.

The following mysql must be run in the `db` container to  update the new database spec (`docker exec -it branchgame_db_1 mysql -u branch -p branch`)

    # So we can separate user info from game info
    # Potentially useful for seasons
    CREATE TABLE IF NOT EXISTS gameData (
      id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
      user_id INT NOT NULL,
      losses INT NOT NULL DEFAULT 0,
      games INT NOT NULL DEFAULT 0,
      wins INT NOT NULL DEFAULT 0,
      elo INT NOT NULL DEFAULT 1500
    );

    # So we can add support for pbkdf2
    ALTER TABLE users ADD enc_type varchar(32) NOT NULL DEFAULT 'sha512';
    ALTER TABLE users MODIFY password VARCHAR(1024) NOT NULL;

    # We're moving information over to the gameData table
    ALTER TABLE users DROP COLUMN losses;
    ALTER TABLE users DROP COLUMN forfeits; # also getting rid of forfeits because they're part of losing
    ALTER TABLE users DROP COLUMN games;
    ALTER TABLE users DROP COLUMN wins;
    ALTER TABLE users DROP COLUMN elo;